### PR TITLE
Dev

### DIFF
--- a/src/main/java/backend/codebackend/domain/Menu.java
+++ b/src/main/java/backend/codebackend/domain/Menu.java
@@ -1,21 +1,29 @@
 package backend.codebackend.domain;
 
+import jakarta.persistence.*;
 import lombok.*;
-
-import java.util.List;
 
 @Getter
 @Setter
+@Entity
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Menu {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) //DB가 ID를 자동으로 생성해 주는 전략 : IDENTITY
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mozipId", referencedColumnName = "id", nullable = true)
+    Mozip mozipId;
+
     private String menuName;
     private String menuPrice;
     private String menuDesc;
+
+    @Lob // Large data를 저장하기 위한 필드임을 나타냄. 안쓰면 저장되지 않음.
+    @Column(name = "menu_photo", columnDefinition = "MEDIUMTEXT")
     private String menuPhoto;
-    private String delivery_fee;
-    private String minPrice;
-    private List<List<Menu>> menuList_Title;
-    private List<String> menuList_Title_Name;
+    private String menuTitle;
 }

--- a/src/main/java/backend/codebackend/repository/MenuRepository.java
+++ b/src/main/java/backend/codebackend/repository/MenuRepository.java
@@ -1,0 +1,12 @@
+package backend.codebackend.repository;
+
+import backend.codebackend.domain.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+    List<Menu> findByMozipId_Id(Long mozipId);
+}

--- a/src/main/java/backend/codebackend/service/MenuService.java
+++ b/src/main/java/backend/codebackend/service/MenuService.java
@@ -1,0 +1,42 @@
+package backend.codebackend.service;
+
+import backend.codebackend.domain.Menu;
+import backend.codebackend.repository.MenuRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MenuService {
+    private final MenuRepository menuRepository;
+
+    public void menuSave(List<Menu> menus) {
+        menuRepository.saveAll(menus);
+    }
+
+    public List<List<Menu>> menuListSelect(Long mozipId) {
+        List<Menu> menus = menuRepository.findByMozipId_Id(mozipId);
+
+        List<List<Menu>> menusList = new ArrayList<>();
+        List<Menu> menuEqualsTitle = new ArrayList<>();
+
+        String menuTitle = "🔥 인기메뉴";
+        for (Menu value : menus) {
+            if (value.getMenuTitle().equals(menuTitle)) {
+                menuEqualsTitle.add(value);
+            } else {
+                menuTitle = value.getMenuTitle();
+                menusList.add(menuEqualsTitle);
+                menuEqualsTitle = new ArrayList<>();
+                menuEqualsTitle.add(value);
+            }
+        }
+
+        return menusList;
+    }
+}

--- a/src/main/resources/static/js/main_page/addStore.js
+++ b/src/main/resources/static/js/main_page/addStore.js
@@ -414,41 +414,51 @@ function createMozip() {
     }
 
     // ----------서버에 모집글 정보 전송------------
-    $.ajax({
-           type : "POST",
-           url : "/mozip",
-           data : {
+    createMozipAndJoinRoom();
+}
+
+async function createMozipAndJoinRoom() {
+    try {
+        const mozip = await $.ajax({
+            type: "POST",
+            url: "/mozip",
+            data: {
                 "mozipTitle" : mozipTitle,
                 "mozipRange" : mozipRange,
                 "mozipCategory" : mozipCategory,
                 "mozipStore" : mozipStore,
                 "mozipPeople" : mozipPeople,
-           },
-           success: function(mozip) {
-               if (chkRoomUserCnt(mozip.id, mozip.nickname)) {
-                   $.ajax({
-                       type: "GET",
-                       url: "/mozip/chat/room?id=" + mozip.id,
-                       data: {
-                       },
-                       async: false,
-                       success: function () {
-                           location.href = "/mozip/chat/room?id=" + mozip.id;
-                       },
-                       error: function () {
-                           alert("실패!");
-                       }
-                   })
-               }
-               console.log("모집글 생성 성공");
-           },
-           error: function(data) {
-               var response = JSON.parse(data.responseText);
-               alert(response.message);
-               console.log(response.message);
-           }
-     })
+            }
+        });
+
+        console.log("모집글 생성 성공.");
+
+        // 메뉴 리스트 크롤링은 작업이 오래 걸리므로 await 없이 비동기로 실행.
+        await $.ajax({
+            type: "POST",
+            url: "/mozip/menuList",
+            data: {
+                "mozipId" : mozip.id
+            }
+        })
+
+        console.log(mozip.id);
+
+        if (chkRoomUserCnt(mozip.id, mozip.nickname)) {
+            await $.ajax({
+                type: "GET",
+                url: "/mozip/chat/room?id=" + mozip.id
+            });
+
+            location.href = "/mozip/chat/room?id=" + mozip.id;
+        }
+    } catch (error) {
+        alert(error.responseText);
+        console.log(error.responseText);
+    }
 }
+
+
 
 // ---------------- 모집글 입장 시 ------------
 let id;

--- a/src/test/java/backend/codebackend/CodeBackendApplicationTests.java
+++ b/src/test/java/backend/codebackend/CodeBackendApplicationTests.java
@@ -1,7 +1,9 @@
 package backend.codebackend;
 
+import backend.codebackend.controller.MainController;
 import backend.codebackend.domain.*;
 import backend.codebackend.dto.ChatDTO;
+import backend.codebackend.dto.MozipForm;
 import backend.codebackend.dto.PaymentDetailsDto;
 import backend.codebackend.dto.TotalPrice;
 import backend.codebackend.repository.BasketRepository;
@@ -16,13 +18,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.*;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.setAllowComparingPrivateFields;
 
 
 @SpringBootTest
@@ -44,16 +42,61 @@ class CodeBackendApplicationTests {
 	MozipService mozipService;
 	@Autowired
 	PaymentsDetailsService paymentsDetailsService;
+	@Autowired
+	MenuService menuService;
+	@Autowired
+	MainController mainController;
+	@Autowired
+	DeliveryInfoService deliveryInfoService;
 
 	@Test
-	@DisplayName("유저 리스트 조회")
-	void 유저리스트조회() {
-		List<String> result = chatUserService.getUserList(87L);
-		List<String> result2 = chatUserService.getUserList(88L);
+	@DisplayName("모집글 생성 테스트")
+	void 모집글생성() throws InterruptedException {
+		Member member = memberService.findLoginId("1234").get();
+		Mozip mozip1 = mozipService.findRoomById(1L).get();
 
-		System.out.println(result);
-		System.out.println(result2);
+		String mozipTitle = "모집글 생성 테스트";
+		int mozipRange = 300;
+		String mozipCategory = "양식";
+		String mozipStore = mozip1.getStore();
+		int mozipPeople = 3;
+
+		String nickname = member.getNickname();
+		//기존에 생성한 방이 있을 경우 생성 제한
+		if (mozipService.findNickName(nickname).isPresent())
+			System.out.println("모집글은 한개만 생성 가능합니다!");
+
+		MozipForm mozipForm = MozipForm.builder()
+				.title(mozipTitle)
+				.distance_limit((long) mozipRange)
+				.categories(mozipCategory)
+				.store(mozipStore)
+				.peoples(mozipPeople)
+				.nickname(nickname)
+				.build();
+
+		Mozip mozip2 = mozipService.savePost(mozipForm);
+		chatUserService.addUser(mozip2.getId(), nickname);
+
+		WebDriver driver = restaurantService.driver(member.getLogin());
+		WebDriverWait wait = restaurantService.getWait(member.getLogin());
+
+		restaurantService.loadPage(driver);
+		restaurantService.searchAddress(member.getAddress(), driver, wait);
+
+		//배달비 조회 후 배달비 정보 엔티티 저장
+		List<Integer> deliveryInfos = restaurantService.searchDeliveryInfo(mozipStore, wait);
+		deliveryInfoService.deliveryInfoSave(mozip2, deliveryInfos.get(0), deliveryInfos.get(1));
+		Long id = mozip2.getId();
+
+		//정산 상태 확인
+		if (mozipService.mozipStatus(id) && chatUserService.isDuplicateName(id, nickname)) {
+			System.out.println("정산 시작된 상태입니다!");
+		}
+
+		System.out.println("입장 성공!!" + id);
 	}
+
 	@Test
 	@DisplayName("모집글 중복 생성 조회")
 	void 모집글중복조회() {
@@ -138,17 +181,14 @@ class CodeBackendApplicationTests {
 	@DisplayName("배달비, 최소주문금액 조회")
 	void 배달비정보조회() throws InterruptedException {
 		Member member = memberService.findLoginId("1234").get();
-		System.out.println(member + "님의 주소는 : " + member.getAddress() + "입니다.");
-		String category = "";
+		Mozip mozip = mozipService.findRoomById(1L).get();
 
-		RestaurantService restaurantService = new RestaurantService();
 		WebDriver driver = restaurantService.driver(member.getLogin());
 		WebDriverWait wait = restaurantService.getWait(member.getLogin());
+
 		restaurantService.loadPage(driver);
-
-		restaurantService.searchAddress("서울특별시 은평구 불광동 산 42-1 각황사", driver, wait);
-
-		List<Integer> deInfo = restaurantService.searchDeliveryInfo("본스치킨-불광북한산점", wait);
+		restaurantService.searchAddress(member.getAddress(), driver, wait);
+		List<Integer> deInfo = restaurantService.searchDeliveryInfo(mozip.getStore(), wait);
 
 		System.out.println("최소주문금액 : " + deInfo.get(0));
 		System.out.println("배달비 : " + deInfo.get(1));
@@ -159,30 +199,38 @@ class CodeBackendApplicationTests {
 	@SneakyThrows
 	@Test
 	@DisplayName("메뉴 리스트 조회 테스트")
-	void 메뉴리스트조회() {
+	void 메뉴리스트조회() throws Exception{
 		try {
 			Member member = memberService.findLoginId("1234").get();
-			System.out.println(member + "님의 주소는 : " + member.getAddress() + "입니다.");
+			Mozip mozip = mozipService.findRoomById(1L).get();
 
 			WebDriver driver = restaurantService.driver(member.getLogin());
 			WebDriverWait wait = restaurantService.getWait(member.getLogin());
-			Future<Menu> m = restaurantService.menuList("24시장안성", member.getAddress(), driver, wait, member.getLogin());
-			Menu menu = m.get();
 
-			for (int i = 0; i < menu.getMenuList_Title().size(); i++) {
-				System.out.println("\n\n[" + menu.getMenuList_Title_Name().get(i) + "]");
-				for (int j = 0; j < menu.getMenuList_Title().get(i).size(); j++) {
-					System.out.println("메뉴 이름 : " + menu.getMenuList_Title().get(i).get(j).getMenuName());
-					System.out.println("메뉴 정보 : " + menu.getMenuList_Title().get(i).get(j).getMenuDesc());
-					System.out.println("메뉴 가격 : " + menu.getMenuList_Title().get(i).get(j).getMenuPrice());
-					System.out.println("메뉴 사진 :  " + menu.getMenuList_Title().get(i).get(j).getMenuPhoto());
-				}
-			}
+			restaurantService.loadPage(driver);
+			restaurantService.searchAddress(member.getAddress(), driver, wait);
+			restaurantService.searchDeliveryInfo(mozip.getStore(), wait);
+
+			CompletableFuture<List<Menu>> future = restaurantService.menuList(mozip, driver, wait, member.getLogin());
+			List<Menu> menus = future.get();
+
+			menuService.menuSave(menus);
+			List<List<Menu>> menuSelect = menuService.menuListSelect(mozip.getId());
+
+			if (menuSelect.isEmpty())
+				System.out.println("데이터 조회 안됨");
+
+            for (List<Menu> menuList : menuSelect) {
+                System.out.println("[" + menuList.get(0).getMenuTitle() + "]");
+                for (Menu menu : menuList) {
+                    System.out.println(menu.getMenuName());
+                    System.out.println(menu.getMenuPrice());
+                }
+                System.out.println();
+            }
+
 		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-		} catch (ExecutionException e) {
-			// ExecutionException 처리 코드
-			e.printStackTrace(); // 예외 스택 트레이스 출력
+			System.out.println(e.getMessage());
 		}
 	}
 
@@ -190,22 +238,22 @@ class CodeBackendApplicationTests {
 	@Test
 	@DisplayName("최소 주문 금액 및 배달 금액 크롤링 테스트")
 	void 배달정보조회() {
-		try{
+		try {
 			Member member = memberService.findLoginId("1234").get();
 			System.out.println(member + "님의 주소는 : " + member.getAddress() + "입니다.");
 
 			WebDriver driver = restaurantService.driver(member.getLogin());
 			WebDriverWait wait = restaurantService.getWait(member.getLogin());
-			Future<Menu> m = restaurantService.menuList("24시장안성", member.getAddress(), driver, wait, member.getLogin());
-			Menu menu = m.get();
 
-			System.out.println("최소 주문 금액 : " + menu.getMinPrice());
-			System.out.println("배달 요금 : " + menu.getDelivery_fee());
+			List<Integer> deliveryInfos = restaurantService.searchDeliveryInfo("24시장안성", wait);
+			restaurantService.loadPage(driver);
+			restaurantService.searchAddress(member.getAddress(), driver, wait);
+
+			for (Integer deliveryInfo : deliveryInfos) {
+				System.out.println(deliveryInfo);
+			}
 		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-		} catch (ExecutionException e) {
-			// ExecutionException 처리 코드
-			e.printStackTrace(); // 예외 스택 트레이스 출력
+			System.out.println(e.getMessage());
 		}
 	}
 
@@ -258,7 +306,7 @@ class CodeBackendApplicationTests {
 	@Test
 	@DisplayName("방 정산 상태 조회")
 	void 정산상태() {
-		System.out.println(mozipService.mozipStatus(95L));
+		System.out.println(mozipService.mozipStatus(22L));
 	}
 
 	@Test


### PR DESCRIPTION
[수정사항] - 가게 메뉴 리스트 크롤링 기능 변화

1. 채팅방 접속 시 가게 메뉴 크롤링 기능은 리소스를 무지막지하게 잡아 먹는 기능임.
  - 모든 사람이 채팅방에 동시에 접속한다고 하면 말도 안되는 크롬 드라이버 리소스를 잡아먹음.
2. 따라서 메뉴를 방장이 글 생성 시 저장하는 형태로 비동기 처리로 크롤링 기능 구현.

[추가 파일]
1. 메뉴 엔티티 생성
  - 모집글 기본키를 참조하는 외래키로 생성 ManyToOne
  - 메뉴 사진이 URL 형태라 길어서 https://github.com/lob 어노테이션 추가해야 됨.
    - 따라서 데이터타입도 바꿔줌
2. 메뉴 서비스, 레포 생성
  - 추가된 레포 메소드 : findByMozipId_Id(Long mozipId)
    - 새로 알게된 형탠데 menu의 외래키를 menuId 객체로 설정함으로써
    - mozipId 객체의 id를 가진 투플을 조회하는 메소드가 된다. => "MozipId_Id"

[변경 파일]
1. RestaurantService의 메뉴 리스트 크롤링 메소드를 수정사항에 반영하여 개선.
  - 또한 크롤링 메소드들을 분리 해줌으로써 재활용이 쉬워지는 형태로 개선.
2. addStore.js의 모집글 생성 AJAX 요청을 프로미스 형태로 개성
  - 콜백 지옥이 될 가능성이 있어 개선해줌.